### PR TITLE
Update foil motion description to multiple water sports

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -17,9 +17,9 @@
     {
       "name": "Foil Motion",
       "url": "https://foilmotion.webchoice.ch/",
-      "sport": ["pumpfoil"],
+      "sport": ["wingfoil", "kitefoil", "kite", "pumpfoil", "windfoil", "windsurf", "efoil", "surffoil", "surf", "downwindfoil"],
       "platforms": ["ios", "apple watch"],
-      "description": "Track your foil sessions with this iOS app."
+      "description": "Accurate GPS tracks for water sports. Stats on pumping frequency and glide time. Cleans up water affected GPS data and calculates speed and postion every 0.5s, great for resolving sharp turns."
     },
     {
       "name": "7III Water",


### PR DESCRIPTION
The new foil motion version released today in the Apple App Store now support tracking multiple other water sports, in addition to pump foiling.